### PR TITLE
Make language selection not cause warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ and either [language-tex](https://atom.io/packages/language-tex) (preferred) or
 
 The package has support for the following TeX Magic comment
 
-*   `%!TeX spellcheck = en-US,en-DE` Select languages
+*   `%!TeX spell_check = en-US,en-DE` Select languages
 
 ## Status
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -2,7 +2,7 @@
 
 import { CompositeDisposable } from 'atom'
 
-const magicSpellCheckPattern = /^%\s*!TEX\s+spellcheck\s*=\s*(.*)$/im
+const magicSpellCheckPattern = /^%\s*!TEX\s+spell_?check\s*=\s*(.*)$/im
 const ignorePattern = /[0-9]+(pt|mm|cm|in|ex|em|bp|pc|dd|cc|sp)/
 const grammarScopes = ['text.tex', 'text.tex.latex', 'text.tex.latex.memoir', 'text.tex.latex.beamer']
 


### PR DESCRIPTION
Allow a format for the language selection comment that does not itself cause a spelling warning.

This allows `%!TeX spell_check = LANGUAGE_CODES` to select the document language, since _spellcheck_ as one word is deemed a spelling mistake by hunspell with `en-US`.
